### PR TITLE
Consume latest major Instabug SDK version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
         multidex = "2.0.1"
         material = "1.0.0"
         androidXAppCompat = "1.3.0"
-        instabugSDK = "10.7.2"
+        instabugSDK = "10+"
         colorPicker = "2.2.3"
         fragmentKtx = "1.3.4"
     }
@@ -35,10 +35,10 @@ allprojects {
         google()
         mavenCentral()
         maven { url "https://jitpack.io" }
-        maven {
+        // maven {
             // TODO add this only if interested in getting SNAPSHOT releases
-            url "https://oss.sonatype.org/content/repositories/snapshots"
-        }
+            // url "https://oss.sonatype.org/content/repositories/snapshots"
+        // }
     }
 }
 


### PR DESCRIPTION
## Description of the change
Update the SDK version to let the app consumes the latest major release 
this requires not to setup maven snapshot repo to prevent the app from consuming the snapshots 
> Description here
## Checklists
### Code review 
- [ ]  This pull request has a descriptive title and information useful to a reviewer. 
- [ ] Changes have been reviewed by at least one other engineer
